### PR TITLE
edit comments, trim whitespace

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -17,7 +17,7 @@ Please follow [best practices](https://github.com/trein/dev-best-practices/wiki/
 
 When your code is ready to be submitted, [submit a pull request](https://help.github.com/articles/creating-a-pull-request/) to begin the code review process.
 
-We only seek to accept code that you are authorized to contribute to the project. We have added a pull request template on our projects so that your contributions are made with the following confirmation: 
+We only seek to accept code that you are authorized to contribute to the project. We have added a pull request template on our projects so that your contributions are made with the following confirmation:
 
 > I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # vSSH
 
-Go library to handle tens of thousands SSH connections and execute the command(s) with higher-level API for building network device / server automation. documentation and examples are available via [godoc](https://godoc.org/github.com/yahoo/vssh).
+Go library to handle tens of thousands SSH connections and execute the command(s) with higher-level API for building network device / server automation. Documentation and examples are available via [godoc](https://godoc.org/github.com/yahoo/vssh).
 
-[![Build Status](https://api.travis-ci.com/yahoo/vssh.svg?branch=master)](https://travis-ci.com/github/yahoo/vssh) 
+[![Build Status](https://api.travis-ci.com/yahoo/vssh.svg?branch=master)](https://travis-ci.com/github/yahoo/vssh)
 [![Go Report Card](https://goreportcard.com/badge/github.com/yahoo/vssh)](https://goreportcard.com/report/github.com/yahoo/vssh)
 [![Coverage Status](https://coveralls.io/repos/github/yahoo/vssh/badge.svg?branch=master&service=github1)](https://coveralls.io/github/yahoo/vssh?branch=master)
 [![GoDoc](https://godoc.org/github.com/yahoo/vssh?status.svg)](https://godoc.org/github.com/yahoo/vssh)
@@ -13,9 +13,9 @@ Go library to handle tens of thousands SSH connections and execute the command(s
 ## Features
 - Connect to multiple remote machines concurrently
 - Persistent SSH connection
-- DSL query based on the labels 
+- DSL query based on the labels
 - Manage number of sessions per SSH connection
-- Limit amount of stdout and stderr data in bytes 
+- Limit amount of stdout and stderr data in bytes
 - Higher-level API for building automation
 
 ### Sample query with label
@@ -24,7 +24,7 @@ labels := map[string]string {
   "POP" : "LAX",
   "OS" : "JUNOS",
 }
-// sets labels to a client 
+// sets labels to a client
 vs.AddClient(addr, config, vssh.SetLabels(labels))
 // query with label
 vs.RunWithLabel(ctx, cmd, timeout, "(POP == LAX || POP == DCA) && OS == JUNOS")
@@ -51,7 +51,7 @@ for resp := range respChan {
     log.Println(err)
       continue
     }
-    
+
   outTxt, errTxt, _ := resp.GetText(vs)
   fmt.Println(outTxt, errTxt, resp.ExitStatus())
 }
@@ -75,7 +75,7 @@ resp := <- respChan
 if err := resp.Err(); err != nil {
   log.Fatal(err)
 }
-  
+
 stream := resp.GetStream()
 defer stream.Close()
 
@@ -92,8 +92,8 @@ for stream.ScanStdout() {
 - Solaris
 
 ## License
-Code is licensed under the Apache License, Version 2.0 (the "License"). 
-Content is licensed under the CC BY 4.0 license. Terms available at https://creativecommons.org/licenses/by/4.0/. 
+Code is licensed under the Apache License, Version 2.0 (the "License").
+Content is licensed under the CC BY 4.0 license. Terms available at https://creativecommons.org/licenses/by/4.0/.
 
 ## Contribute
 Welcomes any kind of contribution, please follow the next steps:

--- a/client.go
+++ b/client.go
@@ -31,12 +31,12 @@ var (
 	dialTimeoutSec = 5
 )
 
-// TimeoutError represents timeout error
+// TimeoutError represents timeout error.
 type TimeoutError struct {
 	error
 }
 
-// MaxSessionsError represents max sessions error
+// MaxSessionsError represents max sessions error.
 type MaxSessionsError struct {
 	error
 }
@@ -63,7 +63,7 @@ type clientAttr struct {
 	sync.RWMutex
 }
 
-// Response represents the response for given session
+// Response represents the response for given session.
 type Response struct {
 	id string
 
@@ -78,8 +78,8 @@ type Response struct {
 	err        error
 }
 
-// Stream represents data stream for given response
-// it provides convenient interfaces to get the returned
+// Stream represents data stream for given response.
+// It provides convenient interfaces to get the returned
 // data real-time.
 type Stream struct {
 	r      *Response
@@ -412,7 +412,7 @@ func (r *Response) cancelTimeout() {
 	close(r.toCancel)
 }
 
-// GetText gets the final result of the given response
+// GetText gets the final result of the given response.
 func (r *Response) GetText(v *VSSH) (string, string, error) {
 	var (
 		data    []byte
@@ -457,17 +457,17 @@ func (r *Response) GetText(v *VSSH) (string, string, error) {
 	return bufOut.String(), bufErr.String(), stream.Err()
 }
 
-// Err returns response error
+// Err returns response error.
 func (r *Response) Err() error {
 	return r.err
 }
 
-// ID returns response identification
+// ID returns response identification.
 func (r *Response) ID() string {
 	return r.id
 }
 
-// GetStream constructs a new stream from a response
+// GetStream constructs a new stream from a response.
 func (r *Response) GetStream() *Stream {
 	if r.err != nil {
 		return nil
@@ -478,14 +478,14 @@ func (r *Response) GetStream() *Stream {
 	}
 }
 
-// ExitStatus returns the exit status of the remote command
+// ExitStatus returns the exit status of the remote command.
 func (r *Response) ExitStatus() int {
 	return r.exitStatus
 }
 
 // ScanStdout provides a convenient interface for reading stdout
 // which it connected to remote host. It reads a line and buffers
-// it. the TextStdout() or BytesStdout() methods returns the buffer
+// it. The TextStdout() or BytesStdout() methods return the buffer
 // in string or bytes.
 func (s *Stream) ScanStdout() bool {
 	if s.done {
@@ -499,19 +499,19 @@ func (s *Stream) ScanStdout() bool {
 	return ok
 }
 
-// TextStdout returns the most recent data that scanned by ScanStdout as string
+// TextStdout returns the most recent data scanned by ScanStdout as string.
 func (s *Stream) TextStdout() string {
 	return string(s.stdout)
 }
 
-// BytesStdout returns the most recent data that scanned by ScanStdout as bytes
+// BytesStdout returns the most recent data scanned by ScanStdout as bytes.
 func (s *Stream) BytesStdout() []byte {
 	return s.stdout
 }
 
 // ScanStderr provides a convenient interface for reading stderr
-// which it connected to remote host. it reads a line and buffer
-// it. the TextStdout() or BytesStdout() methods returns the buffer
+// which it connected to remote host. It reads a line and buffers
+// it. The TextStdout() or BytesStdout() methods return the buffer
 // in string or bytes.
 func (s *Stream) ScanStderr() bool {
 	if s.done {
@@ -525,17 +525,17 @@ func (s *Stream) ScanStderr() bool {
 	return ok
 }
 
-// TextStderr returns the most recent data that scanned by ScanStderr as string
+// TextStderr returns the most recent data scanned by ScanStderr as string.
 func (s *Stream) TextStderr() string {
 	return string(s.stderr)
 }
 
-// BytesStderr returns the most recent data that scanned by ScanStderr as bytes
+// BytesStderr returns the most recent data scanned by ScanStderr as bytes.
 func (s *Stream) BytesStderr() []byte {
 	return s.stderr
 }
 
-// Close cleans up the stream's response
+// Close cleans up the stream's response.
 func (s *Stream) Close() error {
 	if s.r == nil || s.r.session == nil {
 		return errSessNotEst
@@ -549,12 +549,12 @@ func (s *Stream) Close() error {
 	return nil
 }
 
-// Err returns stream response error
+// Err returns stream response error.
 func (s *Stream) Err() error {
 	return s.r.err
 }
 
-// Signal sends the given signal to remote process
+// Signal sends the given signal to remote process.
 func (s *Stream) Signal(sig ssh.Signal) {
 	s.r.sigChan <- sig
 }

--- a/vssh.go
+++ b/vssh.go
@@ -89,10 +89,10 @@ func New() *VSSH {
 	}
 }
 
-// OnDemand changes VSSH connection behavior. by default VSSH
+// OnDemand changes VSSH connection behavior. By default VSSH
 // connects to all of the clients before any run request and
-// it maintains the authenticated SSH connection to all clients
-// we can call this "persistent SSH connection" but with
+// it maintains the authenticated SSH connection to all clients.
+// We can call this "persistent SSH connection" but with
 // OnDemand it tries to connect to clients once the run requested
 // and it closes the appropriate connection once the response data returned.
 func (v *VSSH) OnDemand() *VSSH {
@@ -185,7 +185,7 @@ func clientValidation(c *clientAttr) error {
 }
 
 // Start starts vSSH, including action queue and re-connect procedures.
-// you can construct and start the vssh like below:
+// You can construct and start the vssh like below:
 //	vs := vssh.New().Start()
 func (v *VSSH) Start() *VSSH {
 	ctx := context.Background()
@@ -263,19 +263,19 @@ func (v *VSSH) DecreaseProc(n ...int) {
 	}
 }
 
-// CurrentProc returns number of running processes / workers
+// CurrentProc returns number of running processes / workers.
 func (v *VSSH) CurrentProc() uint64 {
 	return v.stats.processes
 }
 
 // SetInitNumProc sets the initial number of processes / workers.
 //
-// you need to set this number right after create vssh.
+// You need to set this number right after creating vssh.
 //	vs := vssh.New()
 //	vs.SetInitNumProc(200)
 //	vs.Start()
-// there are two other methods which in case you need to change
-// it at the middle of your code.
+// There are two other methods in case you need to change
+// the settings in the middle of your code.
 //	IncreaseProc(n int)
 //	DecreaseProc(n int)
 func (v *VSSH) SetInitNumProc(n int) {
@@ -285,7 +285,7 @@ func (v *VSSH) SetInitNumProc(n int) {
 // Run sends a new run query with given context, command and timeout.
 //
 // timeout allows you to set a limit on the length of time the command
-// will run for. you can cancel the running command by context.WithCancel.
+// will run for. You can cancel the running command by context.WithCancel.
 func (v *VSSH) Run(ctx context.Context, cmd string, timeout time.Duration, opts ...RunOption) chan *Response {
 	respChan := make(chan *Response, 100)
 
@@ -381,7 +381,7 @@ func (v *VSSH) reConnect(ctx context.Context) {
 	}
 }
 
-// ForceReConn reconnects client immediately
+// ForceReConn reconnects the client immediately.
 func (v *VSSH) ForceReConn(addr string) error {
 	client, ok := v.clients.get(addr)
 	if !ok {
@@ -398,7 +398,8 @@ func (v *VSSH) ForceReConn(addr string) error {
 }
 
 // Wait stands by until percentage of the clients have been processed.
-// there is optional perentage as argument otherwise the percentage assumes 100%
+// An optional percentage can be passed as an argument - otherwise the default
+// value of 100% is used.
 func (v *VSSH) Wait(p ...int) (float64, error) {
 	var (
 		start = time.Now()
@@ -444,11 +445,11 @@ func (v *VSSH) SetLogger(l *log.Logger) {
 	v.logger = l
 }
 
-// SetClientsShardNumber sets clients shard number.
+// SetClientsShardNumber sets the clients shard number.
 //
 // vSSH uses map data structure to keep the clients
-// data in the memory. sharding helps to have better performance
-// on write/read with mutex. you can tune it if needed.
+// data in the memory. Sharding helps to have better performance
+// on write/read with mutex. This setting can be tuned if needed.
 func SetClientsShardNumber(n int) {
 	clientsShardNum = n
 }


### PR DESCRIPTION
PR makes editorial changes to the comments (adding periods to sentences etc.) and truncates trailing whitespace (due to editor settings - will help to avoid such "spurious" diffs in the future).

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
