### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ for resp := range respChan {
 ### Stream example
 ```go
 vs := vssh.New().Start()
-config, _ := vssh.GetConfigPEM("mypem.pem")
+config, _ := vssh.GetConfigPEM("vssh", "mypem.pem")
 vs.AddClient("54.193.17.197:22", config, vssh.SetMaxSessions(4))
 vs.Wait()
 


### PR DESCRIPTION
The arguments of example's vssh.GetConfigPEM(user, keyFile string) look different.

https://godoc.org/github.com/yahoo/vssh#GetConfigPEM


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
