### PR TITLE
Fix lost chunks during streaming of large volumes of data.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yahoo/vssh
+module github.com/jmptbl/vssh
 
 go 1.14
 


### PR DESCRIPTION
The current streaming implementation allows for chunks of data to be lost in VSSH's default select{} cases, if volumes of data arrive at a rate too high to be processed.  The default cases get selected when the write channel buffer becomes full and would block.  This patch puts a client into a streaming mode when the GetStream() function is called, which causes a blocking select{} to be used until the streaming mode is ended.


<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
