### PR TITLE
Make StdOut buffer size configurable

### DIFF
--- a/client.go
+++ b/client.go
@@ -48,17 +48,18 @@ type clientStats struct {
 
 // clientAttr represents client attributes
 type clientAttr struct {
-	addr        string
-	labels      map[string]string
-	config      *ssh.ClientConfig
-	client      *ssh.Client
-	logger      *log.Logger
-	maxSessions uint8
-	curSessions uint8
-	lastUpdate  time.Time
-	pty         pty
-	stats       clientStats
-	err         error
+	addr             string
+	labels           map[string]string
+	config           *ssh.ClientConfig
+	client           *ssh.Client
+	logger           *log.Logger
+	maxSessions      uint8
+	curSessions      uint8
+	lastUpdate       time.Time
+	pty              pty
+	stats            clientStats
+	err              error
+	stdOutBufferSize int
 
 	sync.RWMutex
 }
@@ -295,6 +296,11 @@ func (c *clientAttr) getScanners(s *ssh.Session, lOut, lErr int64) (*bufio.Scann
 		scanOut = bufio.NewScanner(lReaderOut)
 	} else {
 		scanOut = bufio.NewScanner(readerOut)
+	}
+
+	if c.stdOutBufferSize != 0 {
+		buf := make([]byte, c.stdOutBufferSize)
+		scanOut.Buffer(buf, c.stdOutBufferSize)
 	}
 
 	if lErr > 0 {

--- a/vssh.go
+++ b/vssh.go
@@ -171,6 +171,14 @@ func SetLabels(labels map[string]string) ClientOption {
 	}
 }
 
+// SetStdOutBufferSize sets stdout buffer size of client
+// This should be set properly if expected output size is larger than 64kb
+func SetStdOutBufferSize(n int) ClientOption {
+	return func(c *clientAttr) {
+		c.stdOutBufferSize = n
+	}
+}
+
 func clientValidation(c *clientAttr) error {
 	if c.config == nil {
 		return errSSHConfig
@@ -186,6 +194,7 @@ func clientValidation(c *clientAttr) error {
 
 // Start starts vSSH, including action queue and re-connect procedures.
 // You can construct and start the vssh like below:
+//
 //	vs := vssh.New().Start()
 func (v *VSSH) Start() *VSSH {
 	ctx := context.Background()
@@ -271,11 +280,14 @@ func (v *VSSH) CurrentProc() uint64 {
 // SetInitNumProc sets the initial number of processes / workers.
 //
 // You need to set this number right after creating vssh.
+//
 //	vs := vssh.New()
 //	vs.SetInitNumProc(200)
 //	vs.Start()
+//
 // There are two other methods in case you need to change
 // the settings in the middle of your code.
+//
 //	IncreaseProc(n int)
 //	DecreaseProc(n int)
 func (v *VSSH) SetInitNumProc(n int) {
@@ -307,14 +319,15 @@ func (v *VSSH) Run(ctx context.Context, cmd string, timeout time.Duration, opts 
 
 // RunWithLabel runs the command on the specific clients which
 // they matched with given query statement.
-//	labels := map[string]string {
-//  	"POP" : "LAX",
-//  	"OS" : "JUNOS",
-//	}
-//	// sets labels to a client
-//	vs.AddClient(addr, config, vssh.SetLabels(labels))
-//	// run the command with label
-//	vs.RunWithLabel(ctx, cmd, timeout, "POP == LAX || POP == DCA) && OS == JUNOS")
+//
+//		labels := map[string]string {
+//	 	"POP" : "LAX",
+//	 	"OS" : "JUNOS",
+//		}
+//		// sets labels to a client
+//		vs.AddClient(addr, config, vssh.SetLabels(labels))
+//		// run the command with label
+//		vs.RunWithLabel(ctx, cmd, timeout, "POP == LAX || POP == DCA) && OS == JUNOS")
 func (v *VSSH) RunWithLabel(ctx context.Context, cmd, queryStmt string, timeout time.Duration, opts ...RunOption) (chan *Response, error) {
 	vis, err := parseExpr(queryStmt)
 	if err != nil {
@@ -342,6 +355,7 @@ func (v *VSSH) RunWithLabel(ctx context.Context, cmd, queryStmt string, timeout 
 }
 
 // SetLimitReaderStdout sets limit for stdout reader.
+//
 //	respChan := vs.Run(ctx, cmd, timeout, vssh.SetLimitReaderStdout(1024))
 func SetLimitReaderStdout(n int64) RunOption {
 	return func(q *query) {


### PR DESCRIPTION
Default buffer size used by bufio.Scanner is 64kb, it will not work if the output is bigger than 64kb, this change makes the StdOut buffer size configurable so that the client code can choose to user default buffer or user defined buffer size. 

<!-- The following line must be included in your pull request -->
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
